### PR TITLE
Fix issue 1 - encode args for url

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.0.3 (2022-06-21)
+------------------
+
+* Encode args before constructing the url, to fix issue when searching for some libraries.
+
 0.0.1 (2022-05-06)
 ------------------
 

--- a/quibraries/search_helpers.py
+++ b/quibraries/search_helpers.py
@@ -1,6 +1,7 @@
 """The Search API caller."""
 import logging
 from typing import List
+from urllib.parse import quote
 
 from .base import LibrariesIOAPIBase
 from .consts import QB_LOGGER
@@ -117,6 +118,8 @@ class SearchAPI(LibrariesIOAPIBase):
         def from_kwargs(*keys):
             return extract(*keys).of(kwargs).then([].append)
 
+        encoded_args = [quote(a, safe="") for a in args]
+
         url_end_list: List[str] = ["https://libraries.io/api"]  # start of list to build url
         if action == "special_project_search":
             url_end_list.append("search?")
@@ -124,7 +127,7 @@ class SearchAPI(LibrariesIOAPIBase):
             url_end_list.append("platforms")
         elif action.startswith("project"):
             action = action[7:]  # remove action prefix
-            url_end_list += [*from_kwargs("platforms", "project"), *args]
+            url_end_list += [*from_kwargs("platforms", "project"), *encoded_args]
             if action.startswith("_"):
                 action = action[1:]  # remove remaining underscore from operation name
                 if action == "dependencies":
@@ -133,11 +136,11 @@ class SearchAPI(LibrariesIOAPIBase):
                 url_end_list.append(action)
         elif action.startswith("repository"):
             action = action[len("repository") :]
-            url_end_list += [*from_kwargs("host", "owner", "repo"), *args]
+            url_end_list += [*from_kwargs("host", "owner", "repo"), *encoded_args]
             if action.startswith("_"):
                 url_end_list.append(action[1:])
         elif "user" in action:
-            url_end_list += [*from_kwargs("host", "user"), *args]
+            url_end_list += [*from_kwargs("host", "user"), *encoded_args]
             if action == "user_repositories":
                 url_end_list.append("repositories")
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(CURRENT_PATH, "requirements_prod.txt"), "r", encoding="ut
 if __name__ == "__main__":
     setup(
         name="quibraries",
-        version="0.0.2",
+        version="0.0.3",
         author="Andreas A. Grammenos",
         author_email="axorl@quine.sh",
         description="A thread-safe Python wrapper for the libraries.io API",


### PR DESCRIPTION
Encode args before creating the url, this will allow packages with slashes (and other characters) to be searched for on libraries.io.

This PR fixes issue 1: https://github.com/andylamp/quibraries/issues/1

The example code given in the issue (copied below) was used for testing, package `github.com/pkg/term` can now be successfully searched for.
```
from quibraries import Search
search = Search("<gituhb_token>")
result = search.project("go", "github.com/pkg/term")
```